### PR TITLE
Allow passing custom validation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ class Comment < ApplicationRecord
 end
 ```
 
+To show a custom error message:
+
+```ruby
+class Comment < ApplicationRecord
+  enum gender: { male: 0, female: 1 }
+
+  validate_enum_attributes :gender, message: "some string msg..."
+end
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/CristiRazvi/enum_attributes_validation.

--- a/lib/enum_attributes_validation.rb
+++ b/lib/enum_attributes_validation.rb
@@ -16,22 +16,22 @@ module EnumAttributesValidation
 
       def check_enum_invalid_attributes
         if enum_invalid_attributes.present?
-          enum_invalid_attributes.each do |key, value|
-            errors.add(key, :invalid_enum, value: value, valid_values: self.class.send(key.to_s.pluralize).keys.sort.join(', '), default: "invalid #{value}")
+          enum_invalid_attributes.each do |key, opts|
+            errors.add(key, opts[:message] || :invalid_enum, value: opts[:value], valid_values: self.class.send(key.to_s.pluralize).keys.sort.join(', '), default: "value provided (#{opts[:value]}) is invalid")
           end
         end
       end
   end
 
   class_methods do
-    def validate_enum_attributes(*attributes)
+    def validate_enum_attributes(*attributes, **opts)
       attributes.each do |attribute|
         string_attribute = attribute.to_s
 
         define_method (string_attribute+"=").to_sym do |argument|
           string_argument = argument.to_s
           self[string_attribute] = string_argument                  if self.class.send(string_attribute.pluralize).keys.include?(string_argument)
-          self.enum_invalid_attributes[attribute] = string_argument unless self.class.send(string_attribute.pluralize).keys.include?(string_argument)
+          self.enum_invalid_attributes[attribute] = opts.merge(value: string_argument) unless self.class.send(string_attribute.pluralize).keys.include?(string_argument)
         end
       end
     end


### PR DESCRIPTION
This resolves #4 by adding the ability to specify a custom message (and cleans up the default slightly).