### PR TITLE
Small fixes for setting enum attributes

### DIFF
--- a/lib/enum_attributes_validation.rb
+++ b/lib/enum_attributes_validation.rb
@@ -35,9 +35,16 @@ module EnumAttributesValidation
         define_method (string_attribute+"=").to_sym do |argument|
           unless argument.blank?
             string_argument = argument.to_s
-            self[string_attribute]                  = string_argument                    if     self.class.send(string_attribute.pluralize).keys.include?(string_argument)
-            self.enum_invalid_attributes[attribute] = opts.merge(value: string_argument) unless self.class.send(string_attribute.pluralize).keys.include?(string_argument)
+
+            if self.class.send(string_attribute.pluralize).keys.include?(string_argument)
+              self.enum_invalid_attributes.delete(attribute)
+              self[string_attribute] = string_argument                    
+            else
+              self.enum_invalid_attributes[attribute] = opts.merge(value: string_argument)
+            end
           end
+
+          self[string_attribute] = nil if argument.nil?
         end
       end
     end

--- a/spec/models/dog.rb
+++ b/spec/models/dog.rb
@@ -84,4 +84,20 @@ describe Dog do
     expect(dog.status).to eq "sad"
   end
 
+  it "sets nil when a valid value is already set" do
+    dog = Dog.new(hair_color: :black)
+    dog.hair_color = nil
+    expect(dog.hair_color).to be nil
+  end
+
+  it "clears errors when after valid value is set" do
+    dog = Dog.new(hair_color: :blue)
+    dog.valid?
+    expect(dog.errors.messages).to include :hair_color
+
+    dog.hair_color = :blonde
+    dog.valid?
+    expect(dog.errors.messages).not_to include :hair_color
+  end
+
 end


### PR DESCRIPTION
The PR includes two changes:
1. When we set an invalid enum value, the error gets added to the `enum_invalid_attributes` hash. Then if later we set a valid value, then the value gets set, but the error has been also kept in the errors, and the validation failed referring to the first, invalid value. With this change, upon setting a valid value for an attribute, that attribute's error is cleared (if there was any).
2. It allows to set `nil` values after a valid value is set for the attribute. There can be optional enum fields, which should be able to reset to `nil` after having a valid value. `nil` values can be handled with database level null constraints, and presence validations.