### PR TITLE
Fix gem version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    enum_attributes_validation (0.1.7)
+    enum_attributes_validation (0.1.8)
       activerecord
       activesupport
 


### PR DESCRIPTION
This change attempts to fix the test failure in the main repo. I ran `bundle` locally, which updated the gem's version in the `Gemfile.lock` file to `0.1.8`. There were no other changes.